### PR TITLE
Add setSize() method for explicitly setting canvas size

### DIFF
--- a/signature-pad.ts
+++ b/signature-pad.ts
@@ -55,6 +55,14 @@ export class SignaturePad {
     this.signaturePad.clear(); // otherwise isEmpty() might return incorrect value
   }
 
+  // sets canvas size explicitly (resize after init)
+  public setSize(padWidth: number, padHeight: number): void {
+      var canvas: any = this.signaturePad._canvas;
+      canvas.width = padWidth;
+      canvas.height = padHeight;
+      this.signaturePad.clear(); // otherwise isEmpty() might return incorrect value
+  }
+
   // Returns signature image as data URL (see https://mdn.io/todataurl for the list of possible paramters)
   public toDataURL(imageType?: string, quality?: number): string {
     return this.signaturePad.toDataURL(imageType, quality); // save image as data URL


### PR DESCRIPTION
As we're not able to make <canvas>'s size "responsive" to its container's size, it would be handy to have a method to set the size explicitly after init.