### PR TITLE
toData and fromData should use an array of point groups

### DIFF
--- a/signature-pad.ts
+++ b/signature-pad.ts
@@ -10,6 +10,8 @@ export interface Point {
   time: number;
 };
 
+export type PointGroup = Point[];
+
 @Component({
   template: '<canvas></canvas>',
   selector: 'signature-pad',
@@ -62,12 +64,12 @@ export class SignaturePad {
   }
 
    // Returns signature image as an array of point groups
-  public toData(): Array<Point> {
+  public toData(): PointGroup[] {
     return this.signaturePad.toData();
   }
 
   // Draws signature image from an array of point groups
-  public fromData(points: Array<Point>): void {
+  public fromData(points: PointGroup[]): void {
     this.signaturePad.fromData(points);
   }
 


### PR DESCRIPTION
The toData function return type was a Point array, but what is actually returned by the code is an array of Point arrays (where each Point array represented a single stroke). Likewise, the fromData parameter was typed as a Point array, but an array of Point arrays is what is actually expected.