### PR TITLE
add public method to get pad object

### DIFF
--- a/signature-pad.ts
+++ b/signature-pad.ts
@@ -127,4 +127,8 @@ export class SignaturePad {
   public onEnd(): void {
     this.onEndEvent.emit(true);
   }
+
+	public queryPad(): any {
+		return this.signaturePad;
+	}
 }


### PR DESCRIPTION
This can be useful when need access the canvas directly. Ex: draw an underline before sign.