### PR TITLE
add @angular/core as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "dependencies": {
     "signature_pad": "2.3.2"
   },
+  "peerDependencies": {
+    "@angular/core": ">= 2.0.1"
+  },
   "devDependencies": {
     "@angular/common": "2.0.1",
     "@angular/compiler": "2.0.1",


### PR DESCRIPTION
The package.json does not list @angular/core as a peerDependency however it is being used in various files

This creates issues with package installers not generating a correct installation layout sometimes, especially when used with yarn workspaces.

To resolve this, @angular/core should be added to package.json/peerDependencies

Example:
https://unpkg.com/@angular/material@10.2.1/package.json